### PR TITLE
FX - Initial GetItem Replacer, Removed Parititoner Cache

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/partition.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/partition.py
@@ -36,7 +36,6 @@ class Partitioner:
         # logger.debug("Compiling graph_module: ", graph_module.code)
         print("Compiling graph_module: ", graph_module.code)
         # FX graph based partitioning based on nvfuser supported ops
-        print("partitioner_cache miss!")
         partitioner = CapabilityBasedPartitioner(
             graph_module, self.supported_ops, allows_single_node_partition=True)
         fused_graph_module = partitioner.partition_and_fuse()

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/partition.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/partition.py
@@ -21,11 +21,6 @@ logger.setLevel(logging.WARNING)
 class Partitioner:
     def __init__(self):
         self.supported_ops = OperatorSupport()
-        # TODO: this is a naive implementation of cache without proper guard
-        self.partitioner_cache: Dict[GraphModule, GraphModule] = {}
-
-        # TODO: this is a naive implementation of cache without proper guard, this will only work for identical inputs
-        self.prim_decomp_cache: Dict[GraphModule, GraphModule] = {}
 
     def fx_serialize(self, graph_module: GraphModule, *args, **kwargs):
         print("Original Graph Module: ", graph_module)
@@ -41,15 +36,10 @@ class Partitioner:
         # logger.debug("Compiling graph_module: ", graph_module.code)
         print("Compiling graph_module: ", graph_module.code)
         # FX graph based partitioning based on nvfuser supported ops
-        if graph_module in self.partitioner_cache:
-            logger.debug("partitioner_cache hit!")
-            print("partitioner_cache hit!")
-            fused_graph_module = self.partitioner_cache[graph_module]
-        else:
-            partitioner = CapabilityBasedPartitioner(
-                graph_module, self.supported_ops, allows_single_node_partition=True)
-            fused_graph_module = partitioner.partition_and_fuse()
-            self.partitioner_cache[graph_module] = fused_graph_module
+        print("partitioner_cache miss!")
+        partitioner = CapabilityBasedPartitioner(
+            graph_module, self.supported_ops, allows_single_node_partition=True)
+        fused_graph_module = partitioner.partition_and_fuse()
 
         return fused_graph_module
 

--- a/src/frontends/pytorch/src/frontend.cpp
+++ b/src/frontends/pytorch/src/frontend.cpp
@@ -21,6 +21,7 @@
 #include "transforms/aten_index_put_replacer.hpp"
 #include "transforms/aten_index_replacer.hpp"
 #include "transforms/aten_stack_list_construct_replacer.hpp"
+#include "transforms/builtin_function_getitem_replacer.hpp"
 #include "transforms/einsum_list_construct.hpp"
 #include "transforms/listconstruct_replacer.hpp"
 #include "transforms/min_max_prim_list_construct_replacer.hpp"
@@ -99,6 +100,7 @@ void FrontEnd::normalize(const std::shared_ptr<ov::Model>& model) const {
     manager.register_pass<ov::frontend::pytorch::pass::AtenStackListConstructReplacer>();
     manager.register_pass<ov::frontend::pytorch::pass::PrimListUnpackReplacer>();
     manager.register_pass<ov::frontend::pytorch::pass::AtenGetItemReplacer>();
+    manager.register_pass<ov::frontend::pytorch::pass::BuiltinFunctionGetItemReplacer>();
     manager.register_pass<ov::frontend::pytorch::pass::ListConstructReplacer>();
     manager.register_pass<ov::frontend::pytorch::pass::AtenIndexToSelect>();
     manager.register_pass<ov::frontend::pytorch::pass::AtenIndexPutReplacer>();

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -132,7 +132,6 @@ OP_CONVERTER(translate_zeros_like);
 
 const std::map<std::string, PytorchCreatorFunction> get_supported_ops() {
     return {
-        {"<built-in function getitem>", op::translate_getitem}, // TODO: Check if there is any other way to handle this
         {"aten::__and__", op::translate_1to1_match_2_inputs<opset10::LogicalAnd>},  // TODO: cover numerical cases
         {"aten::__getitem__", op::translate_getitem},
         {"aten::__not__", op::translate_1to1_match_1_inputs<opset10::LogicalNot>},

--- a/src/frontends/pytorch/src/transforms/builtin_function_getitem_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/builtin_function_getitem_replacer.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "builtin_function_getitem_replacer.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "pt_framework_node.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace pass {
+
+BuiltinFunctionGetItemReplacer::BuiltinFunctionGetItemReplacer() {
+    auto getitem = ov::pass::pattern::wrap_type<ov::op::util::FrameworkNode>();
+
+    ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
+
+        auto getitem = cast_fw_node(m.get_match_root(), "<built-in function getitem>");
+        if (!getitem)
+            return false;
+
+        int64_t axis;
+        auto axis_node = getitem->get_input_node_shared_ptr(1);
+        auto axis_const = std::dynamic_pointer_cast<ov::op::v0::Constant>(axis_node);
+        if (!axis_const)
+            return false;
+        auto _axis = axis_const->cast_vector<int64_t>();
+        if (_axis.size() != 1)
+            return false;
+        axis = _axis[0];
+
+        const auto&& tmp_inputs = get_list_as_outputs(getitem->get_input_source_output(0));
+
+        auto getitem_idx = ov::op::v0::Constant::create(element::i32, Shape{1}, {0});
+        auto zero = ov::op::v0::Constant::create(element::i32, Shape{}, {0});
+        auto result = std::make_shared<ov::op::v8::Gather>(tmp_inputs[axis], getitem_idx, zero);
+        copy_runtime_info(getitem, result);
+        replace_node(getitem, result);
+        result->set_friendly_name(getitem->get_friendly_name());
+
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(getitem, "ov::frontend::pytorch::pass::BuiltinFunctionGetItemReplacer");
+    this->register_matcher(m, callback);
+};
+
+}  // namespace pass
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/transforms/builtin_function_getitem_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/builtin_function_getitem_replacer.cpp
@@ -39,6 +39,8 @@ BuiltinFunctionGetItemReplacer::BuiltinFunctionGetItemReplacer() {
         axis = _axis[0];
 
         const auto&& tmp_inputs = get_list_as_outputs(getitem->get_input_source_output(0));
+        if (tmp_inputs.size() <= axis)
+            return false;
 
         auto getitem_idx = ov::op::v0::Constant::create(element::i32, Shape{1}, {0});
         auto zero = ov::op::v0::Constant::create(element::i32, Shape{}, {0});

--- a/src/frontends/pytorch/src/transforms/builtin_function_getitem_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/builtin_function_getitem_replacer.hpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/pass.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace pass {
+
+class BuiltinFunctionGetItemReplacer : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("ov::frontend::pytorch::pass::BuiltinFunctionGetItemReplacer");
+    BuiltinFunctionGetItemReplacer();
+};
+
+}  // namespace pass
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov


### PR DESCRIPTION
- New replacer added for &#60;built-in function getitem&#62;, corresponding op translation is removed.
- Partitioner cache is removed since it is not needed with the previously added GraphModule cache