### PR TITLE
fx_backend: Additional op support/improvement for Inception V3

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
@@ -14,6 +14,12 @@ import numpy as np
 import inspect
 import ctypes
 
+def maybe_convert_max_int(value : int):
+    if value == 9223372036854775807:
+        return 2147483647
+    else:
+        return value
+
 def fetch_attr(self_module, target : str):
     """
     Fetch an attribute from the ``Module`` hierarchy of ``self.module``.
@@ -478,6 +484,22 @@ class TorchFXPythonDecoder (Decoder):
             # negative index is used to mark inputs initialized by inline constants, there are no such inputs in the graph
             self._inputs = [self._nodes.index(arg) if arg in self._nodes else (arg,) for arg in pt_module.args]
 
+            # FIXME: Find a better way to pass nested tuples to OV frontend. This is a temprary solution to flatten arguments.
+            new_inputs = []
+            for i in range(len(pt_module.args)):
+                expand_list = False
+                if isinstance(pt_module.args[i], list):
+                    for arg in pt_module.args[i]:
+                        if arg in self._nodes:
+                            expand_list = True
+                            break;
+                if expand_list:
+                    for arg in pt_module.args[i]:
+                        new_inputs.append(self._nodes.index(arg))
+                else:
+                    new_inputs.append(self._inputs[i])
+            self._inputs = new_inputs
+
             print(f'[ FX DECODER DEBUG ] inputs: {self._inputs}')
             print(f'[ FX DECODER DEBUG ] outputs: {self._outputs}')
 
@@ -562,12 +584,22 @@ class TorchFXPythonDecoder (Decoder):
 
     def get_type_for_value(self, value):
         print(f'[ FX DECODER DEBUG ] Decoder method called: {inspect.currentframe().f_code.co_name}')
-        if value and ('tensor_meta' in value.meta.keys()):
-            pt_type = value.meta['tensor_meta'].dtype
-            if pt_type in pt_to_ov_type_map:
-                ov_type = pt_to_ov_type_map[pt_type]
-                return OVAny(ov_type)
-        return OVAny(OVType.f32)
+        if issubclass(type(value), torch.fx.Node):
+            if ('tensor_meta' in value.meta.keys()):
+                pt_type = value.meta['tensor_meta'].dtype
+                if pt_type in pt_to_ov_type_map:
+                    ov_type = pt_to_ov_type_map[pt_type]
+                    return OVAny(ov_type)
+            else:
+                return OVAny(OVType.f32)
+        elif isinstance(value, int):
+            return OVAny(OVType.i32)
+        elif isinstance(value, float):
+            return OVAny(OVType.f32)
+        elif isinstance(value, bool):
+            return OVAny(OVType.boolean)
+        else:
+            return OVAny(OVType.f32)
 
     def get_input_transpose_order(self, index):
         print(f'[ FX DECODER DEBUG ] Decoder method called: {inspect.currentframe().f_code.co_name}')
@@ -833,6 +865,7 @@ class TorchFXPythonDecoder (Decoder):
                 elif isinstance(arg, bool):
                     constant = make_constant(OVType.boolean, Shape([]), [arg])
                 elif isinstance(arg, int):
+                    arg = maybe_convert_max_int(arg)
                     constant = make_constant(OVType.i32, Shape([]), [arg])  # TODO: i32? why not i64?
                 elif isinstance(arg, float):
                     constant = make_constant(OVType.f32, Shape([]), [arg])  # TODO: f32? why not f64?

--- a/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
@@ -15,6 +15,8 @@ import inspect
 import ctypes
 
 def maybe_convert_max_int(value : int):
+    # FIXME: This is a convertion from 64-bit positive max integer value
+    # to 32-bit positive max integer value. Find a better way to handle this.
     if value == 9223372036854775807:
         return 2147483647
     else:

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
@@ -153,6 +153,7 @@ class OperatorSupport(OperatorSupport):
             "torch.ops.aten.native_batch_norm.default": None,
             "torch.ops.aten.relu_.default": None,
             "torch.ops.aten.max_pool2d_with_indices.default": None,
+            "torch.ops.aten.add.Tensor": None,
             "torch.ops.aten.add_.Tensor": None,
             "torch.ops.aten.mean.dim": None,
             "torch.ops.aten.view.default": None,
@@ -163,6 +164,12 @@ class OperatorSupport(OperatorSupport):
             "torch.ops.aten.t.default": None,
             "torch.ops.aten.empty.memory_format": None,
             "torch.ops.aten.mul.Tensor": None,
+            "torch.ops.aten.cat.default": None,
+            "torch.ops.aten.avg_pool2d.default": None,
+            "torch.ops.aten._adaptive_avg_pool2d.default": None,
+            "torch.ops.aten.unsqueeze.default": None,
+            "torch.ops.aten.select.int": None,
+            "torch.ops.aten.slice.Tensor": None,
         }
 
         super().__init__(support_dict)
@@ -185,5 +192,3 @@ class OperatorSupport(OperatorSupport):
                 return True
 
         return super().is_node_supported(submodules, node)
-
-

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/partition.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/partition.py
@@ -37,8 +37,7 @@ class Partitioner:
         for partition in partitions:
             for pnode in partition.nodes:
                 for pnode_input in pnode.all_input_nodes:
-                    if pnode_input.op in ['get_attr']:
-                        if pnode_input.op not in getattr_to_merge:
+                    if pnode_input.op in ['get_attr'] and pnode_input.op not in getattr_to_merge:
                             getattr_to_merge[pnode_input] = partition
         for getattr_node, getattr_part in getattr_to_merge.items():
             getattr_part.add_node(getattr_node)

--- a/src/frontends/pytorch/src/op/avg_poolnd.cpp
+++ b/src/frontends/pytorch/src/op/avg_poolnd.cpp
@@ -19,16 +19,22 @@ namespace op {
 using namespace ov::op;
 
 OutputVector translate_avg_poolnd(const NodeContext& context) {
-    num_inputs_check(context, 4, 7);
+    num_inputs_check(context, 3, 7);
     auto input = context.get_input(0);
     auto kernel = context.const_input<Shape>(1);
     auto strides = context.const_input<Strides>(2);
-    auto pads = context.const_input<Shape>(3);  // pytorch supports only symmetric padding
+    bool count_include_pad = true;
+    Shape pads;
+    if (context.input_is_none(3)) {
+        count_include_pad = false;
+        pads = Shape(kernel.size(),0);
+    } else {
+        pads = context.const_input<Shape>(3);  // pytorch supports only symmetric paddings
+    }
     ov::op::RoundingType rounding_type = ov::op::RoundingType::FLOOR;
     if (!(context.input_is_none(4))) {
         rounding_type = context.const_input<bool>(4) ? ov::op::RoundingType::CEIL : ov::op::RoundingType::FLOOR;
     }
-    bool count_include_pad = true;
     if (!(context.input_is_none(5))) {
         count_include_pad = context.const_input<bool>(5);
     }

--- a/src/frontends/pytorch/src/op/avg_poolnd.cpp
+++ b/src/frontends/pytorch/src/op/avg_poolnd.cpp
@@ -19,13 +19,19 @@ namespace op {
 using namespace ov::op;
 
 OutputVector translate_avg_poolnd(const NodeContext& context) {
-    num_inputs_check(context, 6, 7);
+    num_inputs_check(context, 4, 7);
     auto input = context.get_input(0);
     auto kernel = context.const_input<Shape>(1);
     auto strides = context.const_input<Strides>(2);
     auto pads = context.const_input<Shape>(3);  // pytorch supports only symmetric padding
-    auto rounding_type = context.const_input<bool>(4) ? ov::op::RoundingType::CEIL : ov::op::RoundingType::FLOOR;
-    auto count_include_pad = context.const_input<bool>(5);
+    ov::op::RoundingType rounding_type = ov::op::RoundingType::FLOOR;
+    if (!(context.input_is_none(4))) {
+        rounding_type = context.const_input<bool>(4) ? ov::op::RoundingType::CEIL : ov::op::RoundingType::FLOOR;
+    }
+    bool count_include_pad = true;
+    if (!(context.input_is_none(5))) {
+        count_include_pad = context.const_input<bool>(5);
+    }
     FRONT_END_OP_CONVERSION_CHECK(context.input_is_none(6),
                                   "Translation for aten::avg_pool2d do not support divisor_override input.");
     // Although ov::AvgPool provides exclude_pad=false,

--- a/src/frontends/pytorch/src/op/max_poolnd.cpp
+++ b/src/frontends/pytorch/src/op/max_poolnd.cpp
@@ -15,10 +15,15 @@ namespace op {
 using namespace ov::op;
 
 OutputVector translate_max_poolnd(const NodeContext& context) {
-    num_inputs_check(context, 4, 6);
+    num_inputs_check(context, 3, 6);
     auto kernel = context.const_input<Shape>(1);
     auto strides = context.const_input<Strides>(2);
-    auto pads = context.const_input<Shape>(3);  // pytorch supports only symmetric paddings
+    Shape pads;
+    if (context.input_is_none(3)) {
+        pads = Shape(kernel.size(),0);
+    } else {
+        pads = context.const_input<Shape>(3);  // pytorch supports only symmetric paddings
+    }
     Strides dilations;
     if (!context.input_is_none(4)) {
         dilations = context.const_input<Strides>(4);

--- a/src/frontends/pytorch/src/op/slice.cpp
+++ b/src/frontends/pytorch/src/op/slice.cpp
@@ -18,7 +18,7 @@ namespace op {
 
 using namespace ov::op;
 
-OutputVector translate_slice(const NodeContext& context) {
+OutputVector translate_slice_common(const NodeContext& context, const size_t num_inputs) {
     // aten::slice.t(t[] l, int? start=None, int? end=None, int step=1) -> (t[])
     // aten::slice.Tensor(Tensor(a) self, int dim=0, int? start=None, int? end=None, int step=1) -> (Tensor(a))
     ov::Output<ov::Node> dim;
@@ -26,7 +26,7 @@ OutputVector translate_slice(const NodeContext& context) {
     int end_idx;
     int step_idx;
     auto axis_0 = context.mark_node(v0::Constant::create(element::i32, Shape{}, {0}));
-    if (context.get_input_size() == 5) {
+    if (num_inputs == 5) {
         dim = context.get_input(1);
         if (dim.get_partial_shape().rank().is_dynamic() || dim.get_partial_shape().rank().get_length() == 0) {
             dim = context.mark_node(std::make_shared<v0::Unsqueeze>(dim, axis_0));
@@ -34,7 +34,7 @@ OutputVector translate_slice(const NodeContext& context) {
         start_idx = 2;
         end_idx = 3;
         step_idx = 4;
-    } else if (context.get_input_size() == 4) {
+    } else if (num_inputs == 4) {
         start_idx = 1;
         end_idx = 2;
         step_idx = 3;
@@ -72,6 +72,14 @@ OutputVector translate_slice(const NodeContext& context) {
         step = context.mark_node(v0::Constant::create(element::i32, Shape{1}, {1}));
     }
     return {context.mark_node(std::make_shared<v8::Slice>(context.get_input(0), start, end, step, dim))};
+};
+
+OutputVector translate_slice(const NodeContext& context) {
+    return translate_slice_common(context, context.get_input_size());
+};
+
+OutputVector translate_slice_fx(const NodeContext& context) {
+    return translate_slice_common(context, 5);
 };
 
 }  // namespace op

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -29,6 +29,7 @@ OP_CONVERTER(translate_bool);
 OP_CONVERTER(translate_batch_norm);
 OP_CONVERTER(translate_bitwise_not);
 OP_CONVERTER(translate_cat);
+OP_CONVERTER(translate_cat_fx);
 OP_CONVERTER(translate_clamp);
 OP_CONVERTER(translate_constant);
 OP_CONVERTER(translate_conv_transposend);
@@ -109,6 +110,7 @@ OP_CONVERTER(translate_set_item);
 OP_CONVERTER(translate_selu);
 OP_CONVERTER(translate_size);
 OP_CONVERTER(translate_slice);
+OP_CONVERTER(translate_slice_fx);
 OP_CONVERTER(translate_softmax);
 OP_CONVERTER(translate_sort);
 OP_CONVERTER(translate_square);
@@ -366,6 +368,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops_fx() {
     return {
         {"<built-in function getitem>", op::translate_getitem}, // TODO: Check if there is any other way to handle this
         {"aten.convolution.default", op::translate_convolution},
+        {"aten.add.Tensor", op::translate_add},
         {"aten.add_.Tensor", op::translate_add},
         {"aten.addmm.default", op::translate_addmm},
         {"aten.empty.memory_format", op::translate_empty},
@@ -393,6 +396,12 @@ const std::map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"torchvision::nms", op::translate_nms},
         {"torchvision::roi_align", op::translate_roi_align},
         {"aten.mul.Tensor", op::translate_1to1_match_2_inputs_align_types<opset10::Multiply>},
+        {"aten.cat.default", op::translate_cat_fx},
+        {"aten.avg_pool2d.default", op::translate_avg_poolnd},
+        {"aten._adaptive_avg_pool2d.default", op::translate_1to1_match_2_inputs<opset10::AdaptiveAvgPool>},
+        {"aten.unsqueeze.default", op::translate_1to1_match_2_inputs<opset10::Unsqueeze>},
+        {"aten.select.int", op::translate_select},
+        {"aten.slice.Tensor", op::translate_slice_fx},
     };
 };
 


### PR DESCRIPTION
- New op suppport:
    - aten.add.Tensor
    - aten.cat.default
    - aten.avg_pool2d.default
    - aten._adaptive_avg_pool2d.default
    - aten.unsqueeze.default
    - aten.select.int
    - aten.slice.Tensor
- Op translation updates for fx_backend:
    - translate_slice
    - translate_max_poolnd
    - translate_cat
    - translate_avg_poolnd
- Decoder updates for fx_backend input support
    - Temp. fix for nested input tuples
    - Max int value conversion (64-bit max int to 32-bit max int)
    - Input type support for scalar values
- Converted a nested branch into a single branch in partitioning
